### PR TITLE
Add solo session automation scripts and scheduled workflows

### DIFF
--- a/.github/workflows/artifact-on-push.yml
+++ b/.github/workflows/artifact-on-push.yml
@@ -1,0 +1,22 @@
+name: artifact-on-push
+on:
+  push:
+    branches: ["**"]
+jobs:
+  zip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create ZIP
+        run: |
+          REPO_NAME=$(basename "${GITHUB_REPOSITORY}")
+          DATE=$(date +%F-%H%M%S)
+          zip -r "${REPO_NAME}-${DATE}.zip" . -x ".git/*"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-zip
+          path: "*.zip"
+          retention-days: 14

--- a/.github/workflows/auto-end-session.yml
+++ b/.github/workflows/auto-end-session.yml
@@ -1,0 +1,54 @@
+name: auto-end-session
+on:
+  schedule:
+    - cron: "30 3 * * 1-5"  # 23:30 America/Toronto during EDT (Mon-Fri)
+    - cron: "30 4 * * 1-5"  # 23:30 America/Toronto during EST (Mon-Fri)
+  workflow_dispatch:
+
+jobs:
+  end:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config user.name "codex-bot"
+          git config user.email "codex-bot@users.noreply.github.com"
+      - name: Determine today’s session branch (UTC)
+        id: names
+        run: |
+          DATE=$(date -u +%F)
+          BRANCH="ses/${DATE}-auto"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+      - name: Fetch all
+        run: |
+          git fetch --all --tags
+      - name: Squash-merge session branch into main if it exists
+        run: |
+          BRANCH="${{ steps.names.outputs.branch }}"
+          if git rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1; then
+            git checkout main
+            git pull --ff-only
+            git merge --squash "origin/$BRANCH" || true
+            if ! git diff --cached --quiet; then
+              git commit -m "feat: merge ${BRANCH} (auto squash)"
+              git push origin main
+            else
+              echo "No staged changes to commit from ${BRANCH}."
+            fi
+            # Tag release on main
+            REL="rel/$(date -u +%F-%H%M)-auto"
+            git tag -a "$REL" -m "auto release after ${BRANCH}" || true
+            git push origin "$REL" || true
+            # Delete remote branch
+            git push origin --delete "$BRANCH" || true
+          else
+            echo "No session branch found for today ($BRANCH). Skipping."
+          fi
+      - name: End-of-day checkpoint tag on whatever HEAD is
+        run: |
+          TAG="cp/$(date -u +%F-%H%M)-auto-end"
+          git tag -a "$TAG" -m "auto end-of-day checkpoint" || true
+          git push origin "$TAG" || true

--- a/.github/workflows/auto-start-session.yml
+++ b/.github/workflows/auto-start-session.yml
@@ -1,0 +1,42 @@
+name: auto-start-session
+on:
+  schedule:
+    - cron: "0 13 * * 1-5" # 09:00 America/Toronto during EDT (Mon-Fri)
+    - cron: "0 14 * * 1-5" # 09:00 America/Toronto during EST (Mon-Fri)
+  workflow_dispatch:
+
+jobs:
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config user.name "codex-bot"
+          git config user.email "codex-bot@users.noreply.github.com"
+      - name: Determine branch names
+        id: names
+        run: |
+          DATE=$(date -u +%F)
+          BRANCH="ses/${DATE}-auto"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+      - name: Ensure main is up to date
+        run: |
+          git checkout main
+          git pull --ff-only
+      - name: Create or reuse session branch and start tag
+        run: |
+          BRANCH="${{ steps.names.outputs.branch }}"
+          if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch exists: $BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            git commit --allow-empty -m "chore(session): start $BRANCH"
+            git push -u origin "$BRANCH"
+          fi
+          # Tag start (UTC time embedded)
+          TAG="cp/$(date -u +%F-%H%M)-start"
+          git tag -a "$TAG" -m "auto session start $BRANCH" || true
+          git push origin "$TAG" || true

--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -1,0 +1,23 @@
+name: nightly-backup
+on:
+  schedule:
+    - cron: "17 3 * * *"  # ~03:17 UTC nightly
+  workflow_dispatch:
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create timestamped ZIP
+        run: |
+          REPO_NAME=$(basename "${GITHUB_REPOSITORY}")
+          DATE=$(date +%F-%H%M%S)
+          zip -r "${REPO_NAME}-nightly-${DATE}.zip" . -x ".git/*"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-backup
+          path: "*.zip"
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -58,3 +58,32 @@ Batch ingest all JSON files in a directory:
 ```
 
 The ingestor is idempotent (uses `source_hash`), so re-running is safe.
+
+## Solo Session Flow (One-Person Safety Nets)
+
+This repo uses a lightweight solo flow so I can vibe-code safely:
+
+- Work mostly on `main`.
+- Each day at **09:00 Toronto**, CI creates a session branch `ses/YYYY-MM-DD-auto` and a start checkpoint tag.
+- Each night at **23:30 Toronto**, CI will:
+  - squash-merge that session branch into `main` (if there were commits),
+  - create a release tag `rel/YYYY-MM-DD-HHMM-auto`,
+  - delete the session branch.
+- Every push uploads a ZIP artifact. There’s also a nightly backup ZIP.
+
+Manual scripts (local):
+```bash
+./scripts/start_session.sh my-desc     # Start a manual session branch
+./scripts/checkpoint.sh msg             # Make a checkpoint tag + WIP commit
+./scripts/end_session.sh                # Squash-merge back to main + release tag
+```
+
+Note: GitHub’s cron runs in UTC. We schedule both EDT and EST times to cover DST automatically.
+
+Suggested git aliases for faster solo flow:
+```ini
+[alias]
+  st = status -sb
+  lg = log --oneline --graph --decorate --all
+  wip = !f(){ d=$(date +%F-%H%M); git add -A && git commit -m "wip: $d"; }; f
+```

--- a/scripts/checkpoint.sh
+++ b/scripts/checkpoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DESC="${1:-wip}"
+DATE="$(date +%F)"
+TIME="$(date +%H%M)"
+TAG="cp/${DATE}-${TIME}-${DESC}"
+
+# Commit WIP if needed
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git add -A
+  git commit -m "chore(cp): ${TAG}"
+fi
+
+git tag -a "$TAG" -m "checkpoint ${TAG}" || true
+git push origin HEAD --tags
+
+echo "🔖 Checkpoint: $TAG"

--- a/scripts/end_session.sh
+++ b/scripts/end_session.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DATE="$(date +%F)"
+TIME="$(date +%H%M)"
+
+if [[ "$BRANCH" != ses/* ]]; then
+  echo "This doesn't look like a session branch: $BRANCH"
+  exit 0
+fi
+
+./scripts/checkpoint.sh end || true
+
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Squash merge session branch (tolerate no changes)
+if git merge --squash "$BRANCH"; then
+  git commit -m "feat: merge ${BRANCH} (squash)"
+else
+  echo "ℹ️ Nothing to squash from ${BRANCH}."
+fi
+
+git push origin main
+
+REL="rel/${DATE}-${TIME}"
+git tag -a "$REL" -m "release after ${BRANCH}" || true
+git push origin "$REL" || true
+
+# Clean up remote/local branch
+git branch -D "$BRANCH" || true
+git push origin --delete "$BRANCH" || true
+
+echo "✅ Session ended. Release tag: $REL"

--- a/scripts/start_session.sh
+++ b/scripts/start_session.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DESC="${1:-vibe}"
+DATE="$(date +%F)"
+TIME="$(date +%H%M)"
+BRANCH="ses/${DATE}-${DESC}"
+
+REPO_TOP=$(git rev-parse --show-toplevel)
+cd "$REPO_TOP"
+
+# Save any local mess
+git stash push -u -m "pre-session-${DATE}-${TIME}" || true
+
+# Sync main
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+
+# Create or reuse session branch
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  git checkout "$BRANCH"
+else
+  git checkout -b "$BRANCH"
+  git commit --allow-empty -m "chore(session): start ${BRANCH}"
+  git push -u origin "$BRANCH"
+fi
+
+# First checkpoint tag
+TAG="cp/${DATE}-${TIME}-start"
+git tag -a "$TAG" -m "session start ${BRANCH}" || true
+git push origin "$TAG" || true
+
+echo "✅ Session started on branch: $BRANCH"
+echo "   Checkpoint tag: $TAG"


### PR DESCRIPTION
## Summary
- add local session management scripts for manual checkpoints and releases
- configure push, nightly backup, and scheduled auto session GitHub Actions
- document the solo flow and git aliases in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd4939eb1083268fefe714af3fdbac